### PR TITLE
[WIP] Mb/13 endpoint wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/jest": "^23.3.10",
     "@types/node": "^10.12.12",
+    "@types/validator": "^9.4.3",
     "husky": "^1.2.0",
     "jest": "^23.6.0",
     "lint-staged": "^8.1.0",
@@ -42,5 +43,9 @@
       "prettier --write",
       "git add"
     ]
+  },
+  "dependencies": {
+    "axios": "^0.18.0",
+    "validator": "^10.9.0"
   }
 }

--- a/src/api/Endpoint.ts
+++ b/src/api/Endpoint.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import validator from 'validator';
+
+class Endpoint {
+  public uri: string = '';
+  public async load(): Promise<any> {
+    if (validator.isURL(this.uri)) {
+      return axios.get(this.uri);
+    }
+    return Promise.reject('Cannot load data from an invalid endpoint');
+  }
+}
+
+export default Endpoint;

--- a/src/api/People/index.ts
+++ b/src/api/People/index.ts
@@ -1,0 +1,49 @@
+import { PEOPLE_ENDPOINT } from '../../endpoints';
+import { Player } from '../types';
+
+import Endpoint from '../Endpoint';
+
+/**
+ * People endpoint wrapper
+ */
+class People extends Endpoint {
+  constructor(...ids: Array<number>) {
+    super();
+    this.uri = `${PEOPLE_ENDPOINT}?personIds=${ids.join(',')}`;
+  }
+  public async data(): Promise<Array<Player>> {
+    try {
+      const apiData = await this.load();
+      return this.parseData(apiData);
+    } catch (error) {
+      return Promise.reject(error.message);
+    }
+  }
+
+  private async toPlayer(apiData: any): Promise<Player> {
+    const player: Player = {
+      age: apiData.currentAge,
+      birthDate: new Date(apiData.birthDate),
+      birthplace: `${apiData.birthCity}, ${apiData.birthStateProvince || ''} ${apiData.birthCountry}`,
+      dominantSide: apiData.shootsCatches,
+      firstName: apiData.firstName,
+      fullName: apiData.fullName,
+      height: apiData.height,
+      id: apiData.id,
+      isAlternateCaptain: apiData.alternateCaptain,
+      isCaptain: apiData.captain,
+      isRookie: apiData.rookie,
+      jerseyNumber: apiData.primaryNumber,
+      lastName: apiData.lastName,
+      position: apiData.primaryPosition.name,
+      rosterStatus: apiData.rosterStatus,
+      weight: apiData.weight,
+    };
+    return player;
+  }
+  private async parseData(apiData: any): Promise<Array<Player>> {
+    return Promise.all<Player>(apiData.data.people.map((person: any) => this.toPlayer(person)));
+  }
+}
+
+export default People;

--- a/src/api/People/index.ts
+++ b/src/api/People/index.ts
@@ -7,20 +7,7 @@ import Endpoint from '../Endpoint';
  * People endpoint wrapper
  */
 class People extends Endpoint {
-  constructor(...ids: Array<number>) {
-    super();
-    this.uri = `${PEOPLE_ENDPOINT}?personIds=${ids.join(',')}`;
-  }
-  public async data(): Promise<Array<Player>> {
-    try {
-      const apiData = await this.load();
-      return this.parseData(apiData);
-    } catch (error) {
-      return Promise.reject(error.message);
-    }
-  }
-
-  private async toPlayer(apiData: any): Promise<Player> {
+  public static async toPlayer(apiData: any): Promise<Player> {
     const player: Player = {
       age: apiData.currentAge,
       birthDate: new Date(apiData.birthDate),
@@ -41,8 +28,21 @@ class People extends Endpoint {
     };
     return player;
   }
-  private async parseData(apiData: any): Promise<Array<Player>> {
-    return Promise.all<Player>(apiData.data.people.map((person: any) => this.toPlayer(person)));
+  constructor(...ids: Array<number>) {
+    super();
+    this.uri = `${PEOPLE_ENDPOINT}?personIds=${ids.join(',')}`;
+  }
+  public async data(): Promise<Array<Player>> {
+    try {
+      const apiData = await this.load();
+      return this.parseData(apiData);
+    } catch (error) {
+      return Promise.reject(error.message);
+    }
+  }
+
+  public async parseData(apiData: any): Promise<Array<Player>> {
+    return Promise.all<Player>(apiData.data.people.map((person: any) => People.toPlayer(person)));
   }
 }
 

--- a/src/api/Teams/index.ts
+++ b/src/api/Teams/index.ts
@@ -1,15 +1,23 @@
 import { TEAMS_ENDPOINT } from '../../endpoints';
+import { Conference, Division, Team, Venue } from '../types';
+
+import Endpoint from '../Endpoint';
 
 /**
  * Teams endpoint wrapper
  */
-interface Team {
-  id: number;
-}
-class Teams {
-  public uri: string;
+class Teams extends Endpoint {
   constructor(...ids: Array<number>) {
+    super();
     this.uri = `${TEAMS_ENDPOINT}?teamId=${ids.join(',')}`;
+  }
+  public async data(): Promise<Array<Team>> {
+    try {
+      const apiData = await this.load();
+      return this.parseData(apiData);
+    } catch (error) {
+      return Promise.reject(error.message);
+    }
   }
   public withRoster(): this {
     this.uri = `${this.uri}&expand=team.roster`;
@@ -33,10 +41,42 @@ class Teams {
       .withPreviousGame()
       .withNextGame();
   }
-  public fetch(): Team {
+  private toConference(apiData: any): Conference {
     return {
-      id: 0,
+      name: apiData.name,
     };
+  }
+  private toDivision(apiData: any): Division {
+    return {
+      abbreviation: apiData.abbreviation,
+      name: apiData.name,
+    };
+  }
+  private toVenue(apiData: any): Venue {
+    return {
+      city: apiData.city,
+      name: apiData.name,
+      timeZone: apiData.timeZone.tz,
+    };
+  }
+  private toTeam(apiData: any): Team {
+    return {
+      abbreviation: apiData.abbreviation,
+      active: apiData.active,
+      conference: this.toConference(apiData.conference),
+      division: this.toDivision(apiData.division),
+      firstYearOfPlay: apiData.firstYearOfPlay,
+      id: apiData.id,
+      locationName: apiData.locationName,
+      name: apiData.name,
+      shortName: apiData.shortName,
+      siteUrl: apiData.siteUrl,
+      teamName: apiData.teamName,
+      venue: this.toVenue(apiData.venue),
+    };
+  }
+  private async parseData(apiData: Array<any>): Promise<Array<Team>> {
+    return apiData.map(this.toTeam);
   }
 }
 

--- a/src/api/Teams/index.ts
+++ b/src/api/Teams/index.ts
@@ -70,13 +70,13 @@ class Teams extends Endpoint {
       locationName: apiData.locationName,
       name: apiData.name,
       shortName: apiData.shortName,
-      siteUrl: apiData.siteUrl,
+      siteUrl: apiData.officialSiteUrl,
       teamName: apiData.teamName,
       venue: this.toVenue(apiData.venue),
     };
   }
-  private async parseData(apiData: Array<any>): Promise<Array<Team>> {
-    return apiData.map(this.toTeam);
+  private async parseData(apiData: any): Promise<Array<Team>> {
+    return apiData.data.teams.map((team: any) => this.toTeam(team));
   }
 }
 

--- a/src/api/__tests__/__snapshots__/people.test.ts.snap
+++ b/src/api/__tests__/__snapshots__/people.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Api People toPlayer should return a player object with the correct data 1`] = `
+Object {
+  "age": 22,
+  "birthDate": 1990-01-01T00:00:00.000Z,
+  "birthplace": "City of Angels, CA USA",
+  "dominantSide": "R",
+  "firstName": "Cool",
+  "fullName": "Cool Guy",
+  "height": "6' 5\\"",
+  "id": 1,
+  "isAlternateCaptain": false,
+  "isCaptain": true,
+  "isRookie": false,
+  "jerseyNumber": "99",
+  "lastName": "Guy",
+  "position": "Goalie",
+  "rosterStatus": "A",
+  "weight": 222,
+}
+`;

--- a/src/api/__tests__/__snapshots__/teams.test.ts.snap
+++ b/src/api/__tests__/__snapshots__/teams.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Api Teams toTeam should return a team object with the correct data 1`] = `
+Object {
+  "abbreviation": "RZR",
+  "active": true,
+  "conference": Object {
+    "name": "Wild West",
+  },
+  "division": Object {
+    "abbreviation": "GB",
+    "name": "Gummy Bears",
+  },
+  "firstYearOfPlay": 1999,
+  "id": 80085,
+  "locationName": "Battle Dome Zone",
+  "name": "Wreck City Razors",
+  "shortName": "Razors",
+  "siteUrl": "https://getwrecked.co.jp",
+  "teamName": "Razors",
+  "venue": Object {
+    "city": "Tokyooo",
+    "name": "Battle Dome",
+    "timeZoneAbbreviation": "TST",
+    "timeZoneName": "Tokyo Battle Time",
+    "utcOffset": 666,
+  },
+}
+`;

--- a/src/api/__tests__/people.test.ts
+++ b/src/api/__tests__/people.test.ts
@@ -1,0 +1,42 @@
+import People from '../People';
+
+describe('Api', () => {
+  describe('People', () => {
+    describe('toPlayer', () => {
+      const mockApiData = {
+        currentAge: 22,
+        birthDate: '1990-01-01',
+        birthCity: 'City of Angels',
+        birthStateProvince: 'CA',
+        birthCountry: 'USA',
+        shootsCatches: 'R',
+        firstName: 'Cool',
+        fullName: 'Cool Guy',
+        height: '6\' 5"',
+        id: 1,
+        alternateCaptain: false,
+        captain: true,
+        rookie: false,
+        primaryNumber: '99',
+        lastName: 'Guy',
+        primaryPosition: {
+          name: 'Goalie',
+        },
+        rosterStatus: 'A',
+        weight: 222,
+      };
+      it('should return a player object with the correct data', async () => {
+        const player = await People.toPlayer(mockApiData);
+        expect(player).toMatchSnapshot();
+      });
+    });
+    describe('parseData', () => {
+      describe('when no data is passed', () => {
+        it('handles the error', () => {
+          const player = new People(1).parseData(null);
+          expect(player).not.toBeNull();
+        });
+      });
+    });
+  });
+});

--- a/src/api/__tests__/teams.test.ts
+++ b/src/api/__tests__/teams.test.ts
@@ -2,58 +2,147 @@ import Teams from '../Teams';
 
 describe('Api', () => {
   describe('Teams', () => {
-    describe('when not expanding', () => {
-      describe('when requesting one team', () => {
-        const team = new Teams(1);
+    describe('uri', () => {
+      describe('when not expanding', () => {
+        describe('when requesting one team', () => {
+          const team = new Teams(1);
 
-        it('should return the correct uri', () => {
-          expect(team.uri).toBe('https://statsapi.web.nhl.com/api/v1/teams?teamId=1');
+          it('should return the correct uri', () => {
+            expect(team.uri).toBe('https://statsapi.web.nhl.com/api/v1/teams?teamId=1');
+          });
+        });
+        describe('when requesting mutlitple teams', () => {
+          const team = new Teams(1, 2, 3, 4);
+
+          it('should return the correct uri', () => {
+            expect(team.uri).toBe('https://statsapi.web.nhl.com/api/v1/teams?teamId=1,2,3,4');
+          });
         });
       });
-      describe('when requesting mutlitple teams', () => {
-        const team = new Teams(1, 2, 3, 4);
+      describe('when expanding', () => {
+        describe('withRoster', () => {
+          const team = new Teams(1).withRoster();
 
-        it('should return the correct uri', () => {
-          expect(team.uri).toBe('https://statsapi.web.nhl.com/api/v1/teams?teamId=1,2,3,4');
+          it('should return the correct uri', () => {
+            expect(team.uri).toBe('https://statsapi.web.nhl.com/api/v1/teams?teamId=1&expand=team.roster');
+          });
+        });
+        describe('withPreviousGame', () => {
+          const team = new Teams(1).withPreviousGame();
+
+          it('should return the correct uri', () => {
+            expect(team.uri).toBe('https://statsapi.web.nhl.com/api/v1/teams?teamId=1&expand=team.schedule.previous');
+          });
+        });
+        describe('withNextGame', () => {
+          const team = new Teams(1).withNextGame();
+
+          it('should return the correct uri', () => {
+            expect(team.uri).toBe('https://statsapi.web.nhl.com/api/v1/teams?teamId=1&expand=team.schedule.next');
+          });
+        });
+        describe('withStats', () => {
+          const team = new Teams(1).withStats();
+
+          it('should return the correct uri', () => {
+            expect(team.uri).toBe('https://statsapi.web.nhl.com/api/v1/teams?teamId=1&expand=team.stats');
+          });
+        });
+        describe('all', () => {
+          const team = new Teams(1).all();
+
+          it('should return the correct uri', () => {
+            expect(team.uri).toBe(
+              `https://statsapi.web.nhl.com/api/v1/teams?teamId=1&expand=team.roster&expand=team.stats&expand=team.schedule.previous&expand=team.schedule.next`,
+            );
+          });
         });
       });
     });
-    describe('when expanding', () => {
-      describe('withRoster', () => {
-        const team = new Teams(1).withRoster();
-
-        it('should return the correct uri', () => {
-          expect(team.uri).toBe('https://statsapi.web.nhl.com/api/v1/teams?teamId=1&expand=team.roster');
-        });
+    describe('toConference', () => {
+      const mockApiData = {
+        name: 'Wild West',
+      };
+      it('should return a conference object with the correct name', () => {
+        expect(Teams.toConference(mockApiData).name).toBe(mockApiData.name);
       });
-      describe('withPreviousGame', () => {
-        const team = new Teams(1).withPreviousGame();
-
-        it('should return the correct uri', () => {
-          expect(team.uri).toBe('https://statsapi.web.nhl.com/api/v1/teams?teamId=1&expand=team.schedule.previous');
-        });
+    });
+    describe('toDivision', () => {
+      const mockApiData = {
+        abbreviation: 'GB',
+        name: 'Gummy Bears',
+      };
+      it('should return a division object with the correct name', () => {
+        expect(Teams.toDivision(mockApiData).name).toBe(mockApiData.name);
       });
-      describe('withNextGame', () => {
-        const team = new Teams(1).withNextGame();
-
-        it('should return the correct uri', () => {
-          expect(team.uri).toBe('https://statsapi.web.nhl.com/api/v1/teams?teamId=1&expand=team.schedule.next');
-        });
+      it('should return a division object with the correct abbreviation', () => {
+        expect(Teams.toDivision(mockApiData).abbreviation).toBe(mockApiData.abbreviation);
       });
-      describe('withStats', () => {
-        const team = new Teams(1).withStats();
-
-        it('should return the correct uri', () => {
-          expect(team.uri).toBe('https://statsapi.web.nhl.com/api/v1/teams?teamId=1&expand=team.stats');
-        });
+    });
+    describe('toVenue', () => {
+      const mockApiData = {
+        city: 'Tokyooo',
+        name: 'Battle Dome',
+        timeZone: {
+          tz: 'TST',
+          offset: 666,
+          id: 'Tokyo Battle Time',
+        },
+      };
+      it('should return a venue object with the correct city', () => {
+        expect(Teams.toVenue(mockApiData).city).toBe(mockApiData.city);
       });
-      describe('all', () => {
-        const team = new Teams(1).all();
-
-        it('should return the correct uri', () => {
-          expect(team.uri).toBe(
-            `https://statsapi.web.nhl.com/api/v1/teams?teamId=1&expand=team.roster&expand=team.stats&expand=team.schedule.previous&expand=team.schedule.next`,
-          );
+      it('should return a venue object with the correct name', () => {
+        expect(Teams.toVenue(mockApiData).name).toBe(mockApiData.name);
+      });
+      it('should return a venue object with the correct timeZoneName', () => {
+        expect(Teams.toVenue(mockApiData).timeZoneName).toBe(mockApiData.timeZone.id);
+      });
+      it('should return a venue object with the correct timeZoneAbbreviation', () => {
+        expect(Teams.toVenue(mockApiData).timeZoneAbbreviation).toBe(mockApiData.timeZone.tz);
+      });
+      it('should return a venue object with the correct utc offset', () => {
+        expect(Teams.toVenue(mockApiData).utcOffset).toBe(mockApiData.timeZone.offset);
+      });
+    });
+    describe('toTeam', () => {
+      const mockApiData = {
+        abbreviation: 'RZR',
+        active: true,
+        firstYearOfPlay: 1999,
+        id: 80085,
+        locationName: 'Battle Dome Zone',
+        name: 'Wreck City Razors',
+        shortName: 'Razors',
+        officialSiteUrl: 'https://getwrecked.co.jp',
+        teamName: 'Razors',
+        division: {
+          abbreviation: 'GB',
+          name: 'Gummy Bears',
+        },
+        conference: {
+          name: 'Wild West',
+        },
+        venue: {
+          city: 'Tokyooo',
+          name: 'Battle Dome',
+          timeZone: {
+            tz: 'TST',
+            offset: 666,
+            id: 'Tokyo Battle Time',
+          },
+        },
+      };
+      it('should return a team object with the correct data', async () => {
+        const team = await Teams.toTeam(mockApiData, false);
+        expect(team).toMatchSnapshot();
+      });
+    });
+    describe('parseData', () => {
+      describe('when no data is passed', () => {
+        it('handles the error', () => {
+          const team = new Teams(1).parseData(null);
+          expect(team).not.toBeNull();
         });
       });
     });

--- a/src/api/types/Conference.ts
+++ b/src/api/types/Conference.ts
@@ -1,0 +1,3 @@
+export default interface Conference {
+  name: string;
+}

--- a/src/api/types/Division.ts
+++ b/src/api/types/Division.ts
@@ -1,0 +1,4 @@
+export default interface Division {
+  abbreviation: string;
+  name: string;
+}

--- a/src/api/types/Player.ts
+++ b/src/api/types/Player.ts
@@ -1,0 +1,18 @@
+export default interface Player {
+  age: number;
+  birthDate: Date;
+  birthplace: string;
+  dominantSide: string;
+  firstName: string;
+  fullName: string;
+  height: string;
+  id: number;
+  isAlternateCaptain: boolean;
+  isCaptain: boolean;
+  isRookie: boolean;
+  jerseyNumber: string;
+  lastName: string;
+  position: string;
+  rosterStatus: string;
+  weight: number;
+}

--- a/src/api/types/Team.ts
+++ b/src/api/types/Team.ts
@@ -1,0 +1,18 @@
+import Conference from './Conference';
+import Division from './Division';
+import Venue from './Venue';
+
+export default interface Team {
+  abbreviation: string;
+  active: boolean;
+  conference: Conference;
+  division: Division;
+  firstYearOfPlay: string;
+  id: number;
+  locationName: string;
+  name: string;
+  shortName: string;
+  siteUrl: string;
+  teamName: string;
+  venue: Venue;
+}

--- a/src/api/types/Team.ts
+++ b/src/api/types/Team.ts
@@ -1,5 +1,6 @@
 import Conference from './Conference';
 import Division from './Division';
+import Player from './Player';
 import Venue from './Venue';
 
 export default interface Team {
@@ -11,6 +12,7 @@ export default interface Team {
   id: number;
   locationName: string;
   name: string;
+  roster?: Array<Player>;
   shortName: string;
   siteUrl: string;
   teamName: string;

--- a/src/api/types/Venue.ts
+++ b/src/api/types/Venue.ts
@@ -1,0 +1,5 @@
+export default interface Venue {
+  city: string;
+  name: string;
+  timeZone: string;
+}

--- a/src/api/types/Venue.ts
+++ b/src/api/types/Venue.ts
@@ -1,5 +1,7 @@
 export default interface Venue {
   city: string;
   name: string;
-  timeZone: string;
+  timeZoneName: string;
+  timeZoneAbbreviation: string;
+  utcOffset: number;
 }

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -1,0 +1,6 @@
+import Conference from './Conference';
+import Division from './Division';
+import Team from './Team';
+import Venue from './Venue';
+
+export { Conference, Division, Team, Venue };

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -1,6 +1,7 @@
 import Conference from './Conference';
 import Division from './Division';
+import Player from './Player';
 import Team from './Team';
 import Venue from './Venue';
 
-export { Conference, Division, Team, Venue };
+export { Conference, Division, Player, Team, Venue };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
-import Teams from './api/Teams';
+import TeamsEndpoint from './api/Teams';
+
+const Teams = (...ids: Array<number>) => new TeamsEndpoint(...ids);
 
 export default { Teams };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["es2015"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,6 +121,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
   integrity sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==
 
+"@types/validator@^9.4.3":
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-9.4.3.tgz#11321eae0546b20f13020131ff890c294df72ecb"
+  integrity sha512-D4zRrAs2pTg5cva6+hJ6GrQlb/UX5NxNtk/da3Gw27enoLvbRMTTloZ1w6CCqc+kHyZvT3DsyWQZ8baTGgSg0g==
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -350,6 +355,14 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -905,6 +918,13 @@ debug-log@^1.0.1:
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
   integrity sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1368,6 +1388,13 @@ find-up@^3.0.0:
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
+
+follow-redirects@^1.3.0:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -4484,6 +4511,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validator@^10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-10.9.0.tgz#d10c11673b5061fb7ccf4c1114412411b2bac2a8"
+  integrity sha512-hZJcZSWz9poXBlAkjjcsNAdrZ6JbjD3kWlNjq/+vE7RLLS/+8PAj3qVVwrwsOz/WL8jPmZ1hYkRvtlUeZAm4ug==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
# Description

This PR adds the ability to use `withRoster` on team and also introduces the `Endpoint` base class to handle all network requests.

This also converts the slapshot exports to functions over constructors.

before

```
import slapshot from '@hockeybots/slapshot;

const teams = await new slapshot.Teams(1).data();
```

after

```
import slapshot from '@hockeybots/slapshot;

const teams = await slapshot.Teams(1).data();
```

Fixes # (issue) #13 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

```
src/api/__tests__
├── __snapshots__
│   ├── people.test.ts.snap
│   └── teams.test.ts.snap
├── people.test.ts
└── teams.test.ts
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
